### PR TITLE
Fixed critical bug for Categories

### DIFF
--- a/androidClient/app/src/main/java/com/csatimes/dojma/issues/IssuesFragment.java
+++ b/androidClient/app/src/main/java/com/csatimes/dojma/issues/IssuesFragment.java
@@ -39,7 +39,7 @@ public class IssuesFragment extends Fragment {
             creator.add(category, CategoryFragment.class, args);
         }
         final FragmentPagerItemAdapter adapter = new FragmentPagerItemAdapter(
-                getActivity().getSupportFragmentManager(), creator.create()
+                getChildFragmentManager(), creator.create()
         );
 
         viewPager.setAdapter(adapter);


### PR DESCRIPTION
Previously onResume Issues fragment was loosing data. Fixed that by rightfully replacing getActivity().getSupportFragmentManager() with getChildFrangmentManager()