### PR TITLE
minor improvements in archives activity 

### DIFF
--- a/androidClient/app/src/main/java/com/csatimes/dojma/viewholders/ArchiveViewHolder.java
+++ b/androidClient/app/src/main/java/com/csatimes/dojma/viewholders/ArchiveViewHolder.java
@@ -68,6 +68,7 @@ public class ArchiveViewHolder extends RecyclerView.ViewHolder {
     }
 
     public void downloadPdf(final Archive archive) {
+        Toast.makeText(context, "Download has started", Toast.LENGTH_SHORT).show();
         File archives = new File(Environment.getExternalStorageDirectory(), "archives");
         archives.mkdirs();
 
@@ -78,8 +79,10 @@ public class ArchiveViewHolder extends RecyclerView.ViewHolder {
         pathReference
                 .getFile(ifile)
                 .addOnSuccessListener(taskSnapshot -> {
-                    Toast.makeText(context, ifile.getAbsolutePath(), Toast.LENGTH_SHORT).show();
+                    Toast.makeText(context, "Download completed", Toast.LENGTH_SHORT).show();
                     progressBar.setVisibility(View.GONE);
+                    readPdf(ifile);
+
                 })
                 .addOnFailureListener(e -> Log.e(UtilitiesArchivesActivity.TAG, e.getMessage()))
                 .addOnProgressListener(taskSnapshot -> {


### PR DESCRIPTION
Two messages are added to tell the user when the download of archive has started and when it is completed and now the archive will open in the pdf reader app as soon as it is downloaded.